### PR TITLE
Add Hosts File

### DIFF
--- a/.dots/ssh/config
+++ b/.dots/ssh/config
@@ -1,0 +1,3 @@
+# Only require paraphrase once. For OS X Sierra.
+Host *
+   UseKeychain yes

--- a/.dots/ssh/config
+++ b/.dots/ssh/config
@@ -1,3 +1,4 @@
 # Only require paraphrase once. For OS X Sierra.
 Host *
+   AddKeysToAgent yes
    UseKeychain yes

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # Dotfiles
 
-A small set of customizations for OSX that I can't live without.
+A small set of configuration for OSX that I can't live without.
 
 ## Installation
 
 1. Clone this repo.
-2. Execute `setup.bash`
+2. Run `setup.bash`
 3. Add the line `source ~/.dots/profile.sh` to your `.bash_profile`
+
+
+## dotfiles elsewhere
+- https://github.com/grawity/dotfiles

--- a/setup.bash
+++ b/setup.bash
@@ -13,5 +13,5 @@ else
    # copy files to .dots
    cp -R ./.dots/* ~/.dots
 
-   ln -s ~/./dots/ssh/config ~/.ssh/config
+   link ~/.dots/ssh/config ~/.ssh/config
 fi

--- a/setup.bash
+++ b/setup.bash
@@ -11,5 +11,7 @@ else
    curl -o ~/.dots/.git-completion.bash https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash
 
    # copy files to .dots
-   cp ./.dots/* ~/.dots
+   cp -R ./.dots/* ~/.dots
+
+   ln -s ~/./dots/ssh/config ~/.ssh/config
 fi

--- a/setup.bash
+++ b/setup.bash
@@ -2,16 +2,22 @@
 
 # Create dir if not exist.
 if [ -d ~/.dots ]; then
-   echo "Looks like .dots already exists. Not doing anything."
+   echo "Looks like .dots already exists. Not re-creating."
 else
+   echo "Creating ~/.dots"
    mkdir ~/.dots
-
-   # get files for git conveniences.
-   curl -o ~/.dots/.git-prompt.sh https://raw.githubusercontent.com/git/git/master/contrib/completion/git-prompt.sh
-   curl -o ~/.dots/.git-completion.bash https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash
-
-   # copy files to .dots
-   cp -R ./.dots/* ~/.dots
-
-   link ~/.dots/ssh/config ~/.ssh/config
 fi
+
+# get files for git conveniences.
+echo "curling git helper scripts..."
+curl -o ~/.dots/.git-prompt.sh https://raw.githubusercontent.com/git/git/master/contrib/completion/git-prompt.sh
+curl -o ~/.dots/.git-completion.bash https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash
+
+# copy files to .dots
+echo "Copying and updating dotfiles"
+cp -R ./.dots/* ~/.dots
+
+echo "Linking .ssh/config"
+link ~/.dots/ssh/config ~/.ssh/config
+
+printf "\nDone!\n"


### PR DESCRIPTION
## Changes
- Using git and ssh should only prompt for password the first time. As noted here: https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/#adding-your-ssh-key-to-the-ssh-agent
- Update `setup.bash` to update files instead of halting when ~/.dots exists.